### PR TITLE
Add tag support to blog

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -8,6 +8,7 @@ const posts = defineCollection({
     publishDate: z.date(),
     updateDate: z.date().optional(),
     draft: z.boolean().default(false),
+    tags: z.array(z.string()).min(1).max(5).optional(),
   }),
 });
 

--- a/src/content/posts/2020/step-up-your-lwc-skills-part1/index.md
+++ b/src/content/posts/2020/step-up-your-lwc-skills-part1/index.md
@@ -2,6 +2,12 @@
 title: Step Up Your LWC skills - Part 1
 publishDate: 2020-10-27
 description: "LWC tips: getting started, LWC specific idioms, component communication."
+tags:
+  - LWC
+  - JavaScript
+  - Salesforce
+  - Web Components
+  - Best Practices
 ---
 
 > 📝 This post was originally published on the Salesforce developer blog: [link](https://developer.salesforce.com/blogs/2020/10/step-up-your-lwc-skills-part-1.html)

--- a/src/content/posts/2020/step-up-your-lwc-skills-part2/index.md
+++ b/src/content/posts/2020/step-up-your-lwc-skills-part2/index.md
@@ -2,6 +2,12 @@
 title: Step Up Your LWC skills - Part 2
 publishDate: 2020-10-27
 description: "LWC tips: JavaScript best practices, testing & code quality."
+tags:
+  - LWC
+  - JavaScript
+  - Salesforce
+  - Testing
+  - Best Practices
 ---
 
 > 📝 This post was originally published on the Salesforce developer blog: [link](https://developer.salesforce.com/blogs/2020/10/step-up-your-lwc-skills-part-2.html)

--- a/src/content/posts/2021/shadow-dom-and-event-propagation/index.md
+++ b/src/content/posts/2021/shadow-dom-and-event-propagation/index.md
@@ -2,6 +2,12 @@
 title: A complete guide on shadow DOM and event propagation
 publishDate: 2021-04-24
 description: "Explaining everything to know about shadow DOM and event propagation with interactive visuals."
+tags:
+  - Web Components
+  - JavaScript
+  - Shadow DOM
+  - Events
+  - Front-end
 ---
 
 <style>

--- a/src/content/posts/2022/generated-graphql-api-for-salesforce/index.md
+++ b/src/content/posts/2022/generated-graphql-api-for-salesforce/index.md
@@ -2,6 +2,12 @@
 title: Generated GraphQL API for Salesforce
 publishDate: 2022-01-06
 description: "Exploring how to automatically generate a GraphQL API for a Salesforce organization."
+tags:
+  - Salesforce
+  - GraphQL
+  - API
+  - JavaScript
+  - Backend
 ---
 
 > 📣 Here is a small announcement before diving into this post, **Salesforce is currently working on an official GraphQL endpoint**. As of this writing, Salesforce hasn't yet released any public documentation. That said, the official GraphQL endpoint is quite similar to the one presented in this post, with some other nice features 🎉. You can contact [Ben Sklar](mailto:bsklar@salesforce.com) if you would like to try it out.

--- a/src/content/posts/2023/lex-with-lightning-speed/index.md
+++ b/src/content/posts/2023/lex-with-lightning-speed/index.md
@@ -2,6 +2,12 @@
 title: Lightning Experience with Lightning Speed (Are We There Yet?)
 publishDate: 2023-03-15
 description: "Get a closer look into Lightning Experience performance and the next steps planned in the next few releases."
+tags:
+  - Salesforce
+  - Lightning Experience
+  - Performance
+  - Web Performance
+  - Optimization
 ---
 
 > 📝 This post, written by [Bogdan Brinza](https://www.linkedin.com/in/bogdan-brinza/) and myself, was originally published on the Salesforce developer blog: [link](https://developer.salesforce.com/blogs/2023/03/lightning-experience-with-lightning-speed-are-we-there-yet)

--- a/src/content/posts/2023/plan-to-improve-lex-performance/index.md
+++ b/src/content/posts/2023/plan-to-improve-lex-performance/index.md
@@ -2,6 +2,12 @@
 title: Our Detailed Plan to Improve Lightning Experience Performance
 publishDate: 2023-09-10
 description: "Current state of Lightning Experience performance, opportunities we have uncovered, and our next steps."
+tags:
+  - Salesforce
+  - Lightning Experience
+  - Performance
+  - Optimization
+  - Strategy
 ---
 
 > 📝 This post, written by [Bogdan Brinza](https://www.linkedin.com/in/bogdan-brinza/) and myself, was originally published on the Salesforce developer blog: [link](https://developer.salesforce.com/blogs/2023/09/our-detailed-plan-to-improve-lightning-experience-performance)

--- a/src/content/posts/2024/rule-of-five/index.md
+++ b/src/content/posts/2024/rule-of-five/index.md
@@ -2,6 +2,12 @@
 title: The Rule of Five - Making good calls from limited data
 publishDate: 2024-03-04
 description: "A rule of thumb that can be used for making quick estimations when data is limited."
+tags:
+  - Decision Making
+  - Statistics
+  - Estimation
+  - Data Analysis
+  - Productivity
 ---
 
 ![The rule of five banner image](./hero.png)

--- a/src/content/posts/2025/typescript-ai-aided-development/index.md
+++ b/src/content/posts/2025/typescript-ai-aided-development/index.md
@@ -2,6 +2,12 @@
 title: The Unexpected Benefits of Using TypeScript with AI-Aided Development
 publishDate: 2025-05-14
 description: "Exploring how TypeScript provides guardrails for AI coding agents, resulting in higher quality code generation and fewer hallucinations."
+tags:
+  - TypeScript
+  - AI
+  - Code Generation
+  - Developer Tools
+  - JavaScript
 ---
 
 I really appreciate working in TypeScript. For me, developing with TypeScript feels like cycling on a road bike with training wheels: **you get the agility and speed of JavaScript, with the added security of type safety**.

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -3,6 +3,7 @@ import { getCollection } from "astro:content";
 
 import Layout from "../../layouts/Layout.astro";
 import FormattedDate from "../../components/FormattedDate.astro";
+import { slugify } from "../../utils/slug";
 
 import { computeReadTime } from "../../utils/readTime";
 
@@ -16,7 +17,7 @@ export async function getStaticPaths() {
 }
 
 const { post } = Astro.props;
-const { title, description, publishDate, updateDate } = post.data;
+const { title, description, publishDate, updateDate, tags } = post.data;
 
 const meta = {
   type: "post",
@@ -47,6 +48,18 @@ const readTime = computeReadTime(post.body);
 
   <Content />
 
+  {
+    tags && (
+      <p class="tags">
+        {tags.map((tag) => (
+          <a href={`/tags/${slugify(tag)}/`} class="tag">
+            {tag}
+          </a>
+        ))}
+      </p>
+    )
+  }
+
   <p>
     <a href="/posts/">← Back to posts</a>
   </p>
@@ -56,5 +69,13 @@ const readTime = computeReadTime(post.body);
   aside {
     color: var(--color-text-alt);
     font-size: 0.9em;
+  }
+
+  .tags {
+    margin: 1em 0;
+  }
+
+  .tag {
+    margin-right: 0.5em;
   }
 </style>

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -1,0 +1,53 @@
+---
+import Layout from "../../layouts/Layout.astro";
+import FormattedDate from "../../components/FormattedDate.astro";
+import { getPosts, getPostsByTag } from "../../utils/data";
+import { slugify } from "../../utils/slug";
+
+export async function getStaticPaths() {
+  const all = await getPosts();
+  const tags = new Set(all.flatMap((p) => p.data.tags ?? []));
+  return Array.from(tags).map((tag) => ({
+    params: { tag: slugify(tag) },
+    props: { tag },
+  }));
+}
+
+const { tag } = Astro.props;
+const posts = await getPostsByTag(tag);
+
+const meta = {
+  type: "page",
+  title: `Posts tagged "${tag}"`,
+  description: `Posts tagged with ${tag}`,
+} as const;
+---
+
+<Layout meta={meta}>
+  <h1>Posts tagged "{tag}"</h1>
+  <ul>
+    {
+      posts.map((post) => (
+        <li>
+          <FormattedDate date={post.data.publishDate} class="time" />
+          <a href={`/posts/${post.slug}/`}>{post.data.title}</a>
+        </li>
+      ))
+    }
+  </ul>
+</Layout>
+
+<style>
+  ul {
+    list-style: none;
+    padding: 0;
+  }
+
+  li {
+    margin-bottom: 1rem;
+  }
+
+  .time {
+    margin-right: 0.5em;
+  }
+</style>

--- a/src/utils/data.ts
+++ b/src/utils/data.ts
@@ -1,5 +1,6 @@
 import { getCollection } from "astro:content";
 import type { CollectionEntry } from "astro:content";
+import { slugify } from "./slug";
 
 export type Post = CollectionEntry<"posts">;
 export type Book = CollectionEntry<"books">;
@@ -19,6 +20,15 @@ export async function getPosts(options: QueryOptions = {}): Promise<Post[]> {
   });
 
   return posts.slice(offset, offset + (limit ?? posts.length));
+}
+
+export async function getPostsByTag(tag: string): Promise<Post[]> {
+  const slug = slugify(tag);
+
+  const posts = await getPosts();
+  return posts.filter((post) =>
+    post.data.tags?.some((t) => slugify(t) === slug),
+  );
 }
 
 export async function getBooks(): Promise<Book[]> {

--- a/src/utils/slug.ts
+++ b/src/utils/slug.ts
@@ -1,0 +1,6 @@
+export function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+}


### PR DESCRIPTION
## Summary
- store tags in the content collection
- add tags to existing posts
- display post tags and link to tag pages
- create a tag listing page for each tag
- expose helpers for tag slugs and filtering
- allow posts without tags

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849770504388330be37101cb94cdf71